### PR TITLE
Add Laravel devcontainer setup

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,9 @@
+APP_ENV=local
+APP_DEBUG=true
+APP_KEY=
+DB_CONNECTION=mysql
+DB_HOST=db
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=laravel
+DB_PASSWORD=laravel

--- a/.devcontainer/DEVELOPMENT_GUIDE.md
+++ b/.devcontainer/DEVELOPMENT_GUIDE.md
@@ -1,0 +1,17 @@
+# Development Guide
+
+1. Start the dev container using VS Code.
+2. The container installs PHP, Composer and Node.js.
+3. Run Laravel development server:
+   ```bash
+   php artisan serve --host=0.0.0.0 --port=8000
+   ```
+4. For Vite hot reload use:
+   ```bash
+   npm run dev
+   ```
+5. Database credentials inside the container:
+   - Host: `db`
+   - User: `laravel`
+   - Password: `laravel`
+   - Database: `laravel`

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM php:8.3-fpm-bullseye
+
+# Install system packages
+RUN apt-get update && apt-get install -y \
+    git unzip zip libpng-dev libjpeg-dev libfreetype6-dev libonig-dev libxml2-dev \
+    libzip-dev curl gnupg && \
+    docker-php-ext-configure gd --with-freetype --with-jpeg && \
+    docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 22
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+WORKDIR /workspace
+
+CMD ["php-fpm"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "Laravel DevContainer",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "laravel",
+    "workspaceFolder": "/workspace",
+    "remoteUser": "root",
+    "forwardPorts": [8000, 5173],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "felixfbecker.php-intellisense",
+                "bmewburn.vscode-intelephense-client",
+                "onecentlin.laravel-blade",
+                "onecentlin.laravel5-snippets"
+            ]
+        }
+    },
+    "postStartCommand": "bash .devcontainer/postStartCommand.sh"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  laravel:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace
+    ports:
+      - "8000:8000"
+      - "5173:5173"
+    command: sleep infinity
+    networks:
+      - devnet
+    depends_on:
+      - db
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: laravel
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_USER: laravel
+      MYSQL_PASSWORD: laravel
+    volumes:
+      - dbdata:/var/lib/mysql
+    ports:
+      - "3306:3306"
+    networks:
+      - devnet
+volumes:
+  dbdata:
+networks:
+  devnet:

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+composer install --no-interaction || true
+npm install || true
+cp .env.example .env 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+.env.local
+vendor/
+node_modules/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "php.validate.executablePath": "/usr/local/bin/php",
+    "blade.format.enable": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Laravel Serve",
+            "type": "shell",
+            "command": "php",
+            "args": [
+                "artisan",
+                "serve",
+                "--host=0.0.0.0",
+                "--port=8000"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "Laravel Test",
+            "type": "shell",
+            "command": "php",
+            "args": [
+                "artisan",
+                "test"
+            ],
+            "problemMatcher": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # automatic-waffle
+
+This repository contains a minimal Laravel-ready development container.
+
+Open the folder in VS Code with the Dev Containers extension to start
+a container with PHP 8.3, Composer and Node.js preinstalled.
+
+See `.devcontainer/DEVELOPMENT_GUIDE.md` for basic usage.


### PR DESCRIPTION
## Summary
- add devcontainer folder for Laravel development with PHP 8.3, Composer and Node.js
- include Dockerfile, docker-compose and post start script
- provide example environment file and development guide
- add VS Code settings and tasks
- update README and gitignore

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888d195309c832ca0719036c32f7a86