### PR TITLE
Silence postStart errors for missing dependency files

### DIFF
--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
-composer install --no-interaction || true
-npm install || true
+if [ -f composer.json ]; then
+    composer install --no-interaction
+fi
+
+if [ -f package.json ]; then
+    npm install
+fi
 cp .env.example .env 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -5,4 +5,8 @@ This repository contains a minimal Laravel-ready development container.
 Open the folder in VS Code with the Dev Containers extension to start
 a container with PHP 8.3, Composer and Node.js preinstalled.
 
+On startup the container runs `.devcontainer/postStartCommand.sh` which installs
+Composer and npm dependencies when `composer.json` or `package.json` are
+present. If those files do not exist the commands are skipped.
+
 See `.devcontainer/DEVELOPMENT_GUIDE.md` for basic usage.


### PR DESCRIPTION
## Summary
- avoid running composer/npm if their respective files are missing
- document postStart behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888d3ba30d8832c950459b52168f9f6