### PR TITLE
Add CAS login test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,16 @@ See `.devcontainer/DEVELOPMENT_GUIDE.md` for basic usage.
    ```bash
    composer install
    ```
-3. Start the built-in PHP server:
+3. (Optional) Verify your configuration by running the test script:
+   ```bash
+   php test-cas.php
+   ```
+   The script prints the CAS login URL if everything is configured correctly.
+4. Start the built-in PHP server:
    ```bash
    php -S 0.0.0.0:8000 -t public
    ```
-4. Open `http://localhost:8000` in your browser. After CAS authentication you
+5. Open `http://localhost:8000` in your browser. After CAS authentication you
    should see a greeting with your username.
 
 ## SAML Setup

--- a/test-cas.php
+++ b/test-cas.php
@@ -1,0 +1,36 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+// Load environment variables
+if (file_exists(__DIR__ . '/.env')) {
+    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+    $dotenv->load();
+}
+
+
+echo "Testing CAS Authentication...\n";
+
+try {
+    $host = $_ENV['CAS_HOST'] ?? getenv('CAS_HOST');
+    if (!$host) {
+        throw new Exception('CAS_HOST not configured');
+    }
+    $port = $_ENV['CAS_PORT'] ?? getenv('CAS_PORT') ?: 443;
+    $context = $_ENV['CAS_CONTEXT'] ?? getenv('CAS_CONTEXT') ?: '/cas';
+    $caCert = $_ENV['CAS_CA_CERT'] ?? getenv('CAS_CA_CERT');
+    $baseUrl = $_ENV['SERVICE_BASE_URL'] ?? getenv('SERVICE_BASE_URL') ?: '';
+
+    phpCAS::client(CAS_VERSION_2_0, $host, (int)$port, $context, $baseUrl);
+    if ($caCert) {
+        phpCAS::setCasServerCACert($caCert);
+    } else {
+        phpCAS::setNoCasServerValidation();
+    }
+
+    echo "✓ Client configured\n";
+    $loginUrl = phpCAS::getServerLoginURL();
+    echo "✓ Login URL: " . $loginUrl . "\n";
+} catch (Exception $e) {
+    echo "✗ Error: " . $e->getMessage() . "\n";
+}
+


### PR DESCRIPTION
## Summary
- add a simple `test-cas.php` script to verify CAS settings
- document how to use the CAS test script in the README

## Testing
- `composer validate --no-check-lock`
- `php -l test-cas.php`
- `find public saml -name '*.php' -maxdepth 1 -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6888e7c6845c832ca898bdb63ff61c80