### PR TITLE
Fix SAML ACS path

### DIFF
--- a/public/saml-acs.php
+++ b/public/saml-acs.php
@@ -13,7 +13,10 @@ if (file_exists(__DIR__ . '/../.env')) {
 session_start();
 
 try {
-    $settings = require __DIR__ . '/settings.php';
+    // Load SAML settings from the shared configuration file
+    // The file resides in the project "saml" directory one level up
+    // from the public document root.
+    $settings = require __DIR__ . '/../saml/settings.php';
     $auth = new Auth($settings);
     
     // Process SAML Response


### PR DESCRIPTION
## Summary
- fix path for shared SAML settings

## Testing
- `composer install`
- `php test-cas.php` *(fails: CAS_HOST not configured)*
- `php test-saml.php` *(fails: invalid array settings)*

------
https://chatgpt.com/codex/tasks/task_e_6888ebbf8918832c9d06b6e015f8c24c