### PR TITLE
Add DTU SSO defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-# CAS configuration
-CAS_HOST=cas.example.com
+# CAS configuration for DTU's SSO
+CAS_HOST=sso.dtu.dk
 CAS_PORT=443
 CAS_CONTEXT=/cas
-CAS_CA_CERT=/path/to/cacert.pem
+CAS_CA_CERT=/path/to/dtu_cacert.pem
 SERVICE_BASE_URL=http://localhost:8000
 
 # SAML 2.0 configuration
@@ -11,9 +11,9 @@ SP_ACS_URL=https://your-app.example.com/assertion-consumer
 SP_CERT=/path/to/your_sp_cert.pem
 SP_KEY=/path/to/your_sp_key.pem
 
-IDP_ENTITY_ID=https://idp.example.com/adfs/services/trust
-IDP_SSO_URL=https://idp.example.com/adfs/ls/
-IDP_SLO_URL=https://idp.example.com/adfs/ls/?wa=wsignout1.0
+IDP_ENTITY_ID=http://sts.ait.dtu.dk/adfs/services/trust
+IDP_SSO_URL=https://sts.ait.dtu.dk/adfs/ls/
+IDP_SLO_URL=https://sts.ait.dtu.dk/adfs/ls/?wa=wsignout1.0
 IDP_CERT=/path/to/idp_cert.pem
 
 WANT_ASSERTIONS_SIGNED=true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See `.devcontainer/DEVELOPMENT_GUIDE.md` for basic usage.
    ```bash
    php test-cas.php
    ```
-   The script prints the CAS login URL if everything is configured correctly. It
+The script prints the CAS login URL if everything is configured correctly. It
    will warn if `.env` is missing or CAS variables are not set.
 
 4. Start the built-in PHP server:
@@ -39,3 +39,14 @@ If your identity provider offers SAML 2.0 (for example ADFS), download its
 `/federationmetadata/2007-06/` path) and extract the certificate and
 endpoints. The file `SAML_SETUP.md` contains example environment variables and
 explains how to obtain values from the metadata.
+
+## DTU Example Configuration
+
+The repository includes defaults for DTU's Single Sign-On setup. Copy `.env.example` to `.env`
+and the values will point to:
+
+- **CAS**: `sso.dtu.dk`
+- **SAML/ADFS**: `sts.ait.dtu.dk`
+
+With these settings the included `test-cas.php` and `test-saml.php` scripts
+should print DTU login URLs when executed.


### PR DESCRIPTION
## Summary
- configure example env for DTU CAS and ADFS
- document DTU defaults in README

## Testing
- `composer install`
- `php test-cas.php | tail -n 5` *(fails: session handler cannot be changed)*
- `php test-saml.php | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_6888f0051d18832cb1648e94df470081