### PR TITLE
Improve CAS error handling

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -39,13 +39,17 @@ if (!isset($_SESSION['authenticated']) || $_SESSION['authenticated'] !== true) {
             } else {
                 phpCAS::setNoCasServerValidation();
             }
-            
-            phpCAS::forceAuthentication();
-            
-            $_SESSION['authenticated'] = true;
-            $_SESSION['username'] = phpCAS::getUser();
-            $_SESSION['auth_method'] = 'CAS';
-            $_SESSION['login_time'] = date('Y-m-d H:i:s');
+
+            try {
+                phpCAS::forceAuthentication();
+
+                $_SESSION['authenticated'] = true;
+                $_SESSION['username'] = phpCAS::getUser();
+                $_SESSION['auth_method'] = 'CAS';
+                $_SESSION['login_time'] = date('Y-m-d H:i:s');
+            } catch (CAS_AuthenticationException $e) {
+                $error = 'CAS Error: ' . $e->getMessage();
+            }
             
         } elseif ($authMethod === 'saml') {
             // SAML Authentication


### PR DESCRIPTION
## Summary
- catch `CAS_AuthenticationException` and display a friendly message

## Testing
- `composer install`
- `php -l public/index.php`
- `php -l test-cas.php`
- `php -l test-saml.php`
- `php -l saml/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_6888f2e09258832ca1a52439bad47170